### PR TITLE
accept Uint8Array on dispatcher

### DIFF
--- a/denops/sixel_view/main.ts
+++ b/denops/sixel_view/main.ts
@@ -2,13 +2,16 @@ import { Denops } from "https://deno.land/x/denops_std@v5.1.0/mod.ts";
 import { img2sixel } from "./sixel.ts";
 import {
 	assert,
+	isOneOf,
 	isString,
 } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^.ts";
+
+const isUint8Array = (x: unknown): x is Uint8Array => x instanceof Uint8Array;
 
 export function main(denops: Denops): Promise<void> {
 	denops.dispatcher = {
 		img2sixel(source, opts = {}) {
-			assert(source, isString);
+			assert(source, isOneOf([isString, isUint8Array]));
 			return img2sixel(source, opts!);
 		},
 	};

--- a/denops/sixel_view/main.ts
+++ b/denops/sixel_view/main.ts
@@ -1,13 +1,14 @@
 import { Denops } from "https://deno.land/x/denops_std@v5.1.0/mod.ts";
 import { img2sixel } from "./sixel.ts";
-import { isString } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^.ts";
+import {
+	assert,
+	isString,
+} from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^.ts";
 
 export function main(denops: Denops): Promise<void> {
 	denops.dispatcher = {
 		img2sixel(source, opts = {}) {
-			if (!isString(source)) {
-				throw new Error("not string value");
-			}
+			assert(source, isString);
 			return img2sixel(source, opts!);
 		},
 	};

--- a/denops/sixel_view/sixel.ts
+++ b/denops/sixel_view/sixel.ts
@@ -5,7 +5,7 @@ import {
 import { image2sixel } from "npm:sixel";
 
 export async function img2sixel(
-	source: string,
+	source: string | Uint8Array,
 	opts?:
 		| {
 			maxWidth?: number;


### PR DESCRIPTION
It is useful when the other denops plugin which use Uint8Array use `denops.dispatch("sixel_view", "img2sixel", file);`.

For example...
```typescript
const file: Uint8Array = await downloadFile(url);
const sixel = denops.dispatch("sixel_view", "img2sixel", file);
  // ↑ before this PR this line is Error (file is not String)
```